### PR TITLE
[ADD] 토큰 리프레시 후 갱신 기능 작성

### DIFF
--- a/src/main/kotlin/com/jongho/hobbytalk/api/user/command/application/service/AuthUserService.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/user/command/application/service/AuthUserService.kt
@@ -1,8 +1,8 @@
-package com.jongho.hobbytalk.api.user.command.application.repository
+package com.jongho.hobbytalk.api.user.command.application.service
 
 import com.jongho.hobbytalk.api.user.command.domain.model.AuthUser
 
-interface AuthUserRepository {
+interface AuthUserService {
     fun save(authUser: AuthUser)
     fun findOneByUserId(userId: Long): AuthUser?
 }

--- a/src/main/kotlin/com/jongho/hobbytalk/api/user/command/application/service/AuthUserServiceImpl.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/user/command/application/service/AuthUserServiceImpl.kt
@@ -1,0 +1,14 @@
+package com.jongho.hobbytalk.api.user.command.application.service
+
+import com.jongho.hobbytalk.api.user.command.application.repository.AuthUserRepository
+import com.jongho.hobbytalk.api.user.command.domain.model.AuthUser
+
+class AuthUserServiceImpl(private val authUserRepository: AuthUserRepository): AuthUserService {
+    override fun save(authUser: AuthUser) {
+        authUserRepository.save(authUser = authUser)
+    }
+
+    override fun findOneByUserId(userId: Long): AuthUser? {
+        return authUserRepository.findOneByUserId(userId = userId)
+    }
+}

--- a/src/main/kotlin/com/jongho/hobbytalk/api/user/command/application/usecase/TokenRefreshUseCase.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/user/command/application/usecase/TokenRefreshUseCase.kt
@@ -1,0 +1,29 @@
+package com.jongho.hobbytalk.api.user.command.application.usecase
+
+import com.jongho.hobbytalk.api.user.command.application.dto.response.TokenResponse
+import com.jongho.hobbytalk.api.user.command.application.service.AuthUserService
+import com.jongho.hobbytalk.api.user.command.common.exception.UnAuthorizedException
+import com.jongho.hobbytalk.api.user.command.common.exception.UserNotFoundException
+import com.jongho.hobbytalk.api.user.command.common.util.token.TokenUtil
+import org.springframework.transaction.annotation.Transactional
+
+class TokenRefreshUseCase(
+    private val authUserService: AuthUserService,
+    private val tokenUtil: TokenUtil ) {
+
+    @Transactional
+    fun execute(userId: Long, refreshToken: String): TokenResponse {
+        val authUser = authUserService.findOneByUserId(userId) ?: throw UserNotFoundException("존재하지 않는 유저입니다.")
+
+        if(authUser.refreshToken == null || authUser.refreshToken != refreshToken) {
+            throw UnAuthorizedException("유효하지 않는 토큰입니다.")
+        }
+
+        val aToken = tokenUtil.createAccessToken(userId = userId)
+        val rToken = tokenUtil.createRefreshToken(userId = userId)
+
+        authUserService.save(authUser = authUser.copy(refreshToken = rToken))
+
+        return TokenResponse(accessToken = aToken, refreshToken = rToken)
+    }
+}

--- a/src/main/kotlin/com/jongho/hobbytalk/api/user/command/domain/model/AuthUser.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/user/command/domain/model/AuthUser.kt
@@ -2,5 +2,12 @@ package com.jongho.hobbytalk.api.user.command.domain.model
 
 class AuthUser (
     val userId: Long,
-    val refreshToken: String
-)
+    val refreshToken: String?
+) {
+    fun copy(
+    userId: Long = this.userId,
+    refreshToken: String? = this.refreshToken
+    ): AuthUser {
+        return AuthUser(userId, refreshToken)
+    }
+}

--- a/src/test/kotlin/com/jongho/hobbytalk/api/mock/user/UserContainer.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/mock/user/UserContainer.kt
@@ -5,9 +5,11 @@ import com.jongho.hobbytalk.api.mock.common.CommonContainer
 import com.jongho.hobbytalk.api.mock.common.getCommonContainer
 import com.jongho.hobbytalk.api.mock.user.repository.FakeAuthUserRepositoryImpl
 import com.jongho.hobbytalk.api.mock.user.repository.FakeUserRepositoryImpl
+import com.jongho.hobbytalk.api.user.command.application.service.AuthUserServiceImpl
 import com.jongho.hobbytalk.api.user.command.application.service.UserServiceImpl
 import com.jongho.hobbytalk.api.user.command.application.usecase.SignInUseCase
 import com.jongho.hobbytalk.api.user.command.application.usecase.SignUpUseCase
+import com.jongho.hobbytalk.api.user.command.application.usecase.TokenRefreshUseCase
 import com.jongho.hobbytalk.api.user.command.common.util.hash.PasswordHashUtil
 import com.jongho.hobbytalk.api.user.command.common.util.token.TokenUtil
 
@@ -23,11 +25,16 @@ class UserContainer (){
             userService = this.get(UserBeanKey.USER_SERVICE)
         )
         map[UserBeanKey.AUTH_USER_REPOSITORY.getValue()] = FakeAuthUserRepositoryImpl()
+        map[UserBeanKey.AUTH_USER_SERVICE.getValue()] = AuthUserServiceImpl(this.get(UserBeanKey.AUTH_USER_REPOSITORY))
         map[UserBeanKey.SIGN_IN_USE_CASE.getValue()] = SignInUseCase(
             tokenUtil = commonContainer.get<TokenUtil>(CommonBeanKey.TOKEN_UTIL),
             hashUtil = commonContainer.get<PasswordHashUtil>(CommonBeanKey.PASSWORD_HASH_UTIL),
             userService = this.get(UserBeanKey.USER_SERVICE),
             authUserRepository = this.get(UserBeanKey.AUTH_USER_REPOSITORY),
+        )
+        map[UserBeanKey.TOKEN_REFRESH_USE_CASE.getValue()] = TokenRefreshUseCase(
+            tokenUtil = commonContainer.get<TokenUtil>(CommonBeanKey.TOKEN_UTIL),
+            authUserService = this.get(UserBeanKey.AUTH_USER_SERVICE)
         )
     }
 
@@ -41,8 +48,10 @@ enum class UserBeanKey(private val value: String) {
     USER_REPOSITORY("UserRepository"),
     USER_SERVICE("UserService"),
     SIGN_UP_USE_CASE("SignUpUseCase"),
+    AUTH_USER_SERVICE("AuthUserService"),
     AUTH_USER_REPOSITORY("AuthUserRepository"),
-    SIGN_IN_USE_CASE("SignInUseCase");
+    SIGN_IN_USE_CASE("SignInUseCase"),
+    TOKEN_REFRESH_USE_CASE("TokenRefreshUseCase");
 
     fun getValue(): String {
         return value

--- a/src/test/kotlin/com/jongho/hobbytalk/api/mock/user/repository/FakeAuthUserRepositoryImpl.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/mock/user/repository/FakeAuthUserRepositoryImpl.kt
@@ -21,7 +21,7 @@ class FakeAuthUserRepositoryImpl: AuthUserRepository {
         return authUserList.firstOrNull{authUser -> authUser.userId == userId }
     }
 
-    fun clenUp() {
+    fun cleanUp() {
         authUserList = mutableListOf()
     }
 }

--- a/src/test/kotlin/com/jongho/hobbytalk/api/mock/user/repository/FakeAuthUserRepositoryImpl.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/mock/user/repository/FakeAuthUserRepositoryImpl.kt
@@ -2,7 +2,6 @@ package com.jongho.hobbytalk.api.mock.user.repository
 
 import com.jongho.hobbytalk.api.user.command.application.repository.AuthUserRepository
 import com.jongho.hobbytalk.api.user.command.domain.model.AuthUser
-import java.util.concurrent.atomic.AtomicLong
 
 class FakeAuthUserRepositoryImpl: AuthUserRepository {
     private var authUserList: MutableList<AuthUser> = mutableListOf()
@@ -16,6 +15,10 @@ class FakeAuthUserRepositoryImpl: AuthUserRepository {
         else {
             authUserList.add(i, authUser)
         }
+    }
+
+    override fun findOneByUserId(userId: Long): AuthUser? {
+        return authUserList.firstOrNull{authUser -> authUser.userId == userId }
     }
 
     fun clenUp() {

--- a/src/test/kotlin/com/jongho/hobbytalk/api/mock/user/repository/FakeUserRepositoryImpl.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/mock/user/repository/FakeUserRepositoryImpl.kt
@@ -36,7 +36,7 @@ class FakeUserRepositoryImpl: UserRepository {
         return userId
     }
 
-    fun clenUp() {
+    fun cleanUp() {
         userList = mutableListOf()
         id = AtomicLong(0)
     }

--- a/src/test/kotlin/com/jongho/hobbytalk/api/user/application/service/UserServiceImplTest.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/user/application/service/UserServiceImplTest.kt
@@ -37,7 +37,7 @@ class UserServiceImplTest {
                 password = "1234",
                 nickname = "종호",
                 createdTime = LocalDateTime.now())
-            userContainer.get<FakeUserRepositoryImpl>(UserBeanKey.USER_REPOSITORY).clenUp()
+            userContainer.get<FakeUserRepositoryImpl>(UserBeanKey.USER_REPOSITORY).cleanUp()
         }
 
         @Test

--- a/src/test/kotlin/com/jongho/hobbytalk/api/user/application/usecase/SignInUseCaseImplTest.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/user/application/usecase/SignInUseCaseImplTest.kt
@@ -52,8 +52,8 @@ class SignInUseCaseImplTest {
 
         @AfterEach
         fun cleanUp() {
-            userRepository.clenUp()
-            authUserRepository.clenUp()
+            userRepository.cleanUp()
+            authUserRepository.cleanUp()
         }
 
         @Test

--- a/src/test/kotlin/com/jongho/hobbytalk/api/user/application/usecase/SignUpUseCaseImplTest.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/user/application/usecase/SignUpUseCaseImplTest.kt
@@ -29,7 +29,7 @@ class SignUpUseCaseImplTest {
         @BeforeEach
         fun cleanUp() {
 
-            userContainer.get<FakeUserRepositoryImpl>(UserBeanKey.USER_REPOSITORY).clenUp()
+            userContainer.get<FakeUserRepositoryImpl>(UserBeanKey.USER_REPOSITORY).cleanUp()
         }
 
         @Test

--- a/src/test/kotlin/com/jongho/hobbytalk/api/user/application/usecase/TokenRefreshUseCaseImplTest.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/user/application/usecase/TokenRefreshUseCaseImplTest.kt
@@ -39,7 +39,7 @@ class TokenRefreshUseCaseImplTest {
 
         @AfterEach
         fun cleanUp() {
-            authUserRepository.clenUp()
+            authUserRepository.cleanUp()
         }
 
         @Test

--- a/src/test/kotlin/com/jongho/hobbytalk/api/user/application/usecase/TokenRefreshUseCaseImplTest.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/user/application/usecase/TokenRefreshUseCaseImplTest.kt
@@ -1,0 +1,95 @@
+package com.jongho.hobbytalk.api.user.application.usecase
+
+import com.jongho.hobbytalk.api.mock.common.util.FakeTokenUtilImpl
+import com.jongho.hobbytalk.api.mock.user.UserBeanKey
+import com.jongho.hobbytalk.api.mock.user.UserContainer
+import com.jongho.hobbytalk.api.mock.user.getUserContainer
+import com.jongho.hobbytalk.api.mock.user.repository.FakeAuthUserRepositoryImpl
+import com.jongho.hobbytalk.api.user.command.application.dto.response.TokenResponse
+import com.jongho.hobbytalk.api.user.command.application.usecase.TokenRefreshUseCase
+import com.jongho.hobbytalk.api.user.command.common.exception.UnAuthorizedException
+import com.jongho.hobbytalk.api.user.command.common.exception.UserNotFoundException
+import com.jongho.hobbytalk.api.user.command.domain.model.AuthUser
+import org.junit.jupiter.api.*
+import org.springframework.context.annotation.Description
+import kotlin.test.assertEquals
+
+@Description("TokenRefreshUseCase 클래스")
+class TokenRefreshUseCaseImplTest {
+    private val tokenRefreshUseCase: TokenRefreshUseCase;
+    private val userContainer: UserContainer = getUserContainer()
+
+    init {
+        tokenRefreshUseCase = userContainer.get(UserBeanKey.TOKEN_REFRESH_USE_CASE)
+    }
+
+    @Nested
+    @Description("execute 메소드는")
+    inner class ExecuteMethod{
+        private val authUserRepository = userContainer.get<FakeAuthUserRepositoryImpl>(UserBeanKey.AUTH_USER_REPOSITORY)
+        private val tokenUtil = FakeTokenUtilImpl()
+        private var authUser = AuthUser(userId = 1L, refreshToken = tokenUtil.createRefreshToken(1L))
+        @BeforeEach
+        fun setUp() {
+            authUser = AuthUser(userId = 1L, refreshToken = tokenUtil.createRefreshToken(1L))
+            authUserRepository.save(
+                authUser = authUser
+            )
+        }
+
+        @AfterEach
+        fun cleanUp() {
+            authUserRepository.clenUp()
+        }
+
+        @Test
+        @Description("토큰 재발급에 성공할 경우 인증유저가 업데이트 되고 A-T, R-T를 가진 TokenResponse를 반환 받는다.")
+        fun 토큰_재발급에_성공할_경우_인증유저가_업데이트_되고_TokenResponse를_반환_받는다() {
+            //given
+            val expectedTokenResponse = TokenResponse(
+                accessToken = tokenUtil.createAccessToken(1L),
+                refreshToken = tokenUtil.createRefreshToken(1L)
+            )
+            //when
+            val actual = tokenRefreshUseCase.execute(userId = authUser.userId, refreshToken = authUser.refreshToken!!)
+
+            //then
+            assertEquals(expectedTokenResponse.accessToken, actual.accessToken)
+            assertEquals(expectedTokenResponse.refreshToken, actual.refreshToken)
+        }
+
+        @Test
+        @Description("존재하지 않는 유저가 토큰 갱신을 시도할 경우 UserNotFoundException과 존재하지 않는 유저입니다.메세지를 던진다.")
+        fun 존재하지_않는_유저가_토큰_갱신을_시도할_경우_UserNotFoundException과_존재하지_않는_유저입니다_메세지를_던진다() {
+            //given
+            authUser = AuthUser(
+                userId = 2L,
+                refreshToken = null
+            )
+            val expected = UserNotFoundException("존재하지 않는 유저입니다.")
+
+            //when
+            val actual = assertThrows<UserNotFoundException>{ tokenRefreshUseCase.execute(authUser.userId, refreshToken = "") }
+
+            //then
+            assertEquals(expected.message, actual.message)
+        }
+
+        @Test
+        @Description("리프레시 토큰이 유효하지 않을 경우 UnAuthorizedException과 유효하지 않는 토큰입니다.메세지를 던진다.")
+        fun 리프레시_토큰이_유효하지_않을_경우_UserNotFoundException과_유효하지_않는_토큰입니다_메세지를_던진다() {
+            //given
+            authUser = AuthUser(
+                userId = 1L,
+                refreshToken = "null"
+            )
+            val expected = UnAuthorizedException("유효하지 않는 토큰입니다.")
+
+            //when
+            val actual = assertThrows<UnAuthorizedException>{ tokenRefreshUseCase.execute(authUser.userId, refreshToken = authUser.refreshToken!!) }
+
+            //then
+            assertEquals(expected.message, actual.message)
+        }
+    }
+}


### PR DESCRIPTION
✨ 기능 설명
<!-- 구현한 기능에 대한 간단한 설명을 작성해주세요. -->
사용자의 리프레시 토큰을 검증하여 새로운 액세스 토큰 및 리프레시 토큰을 발급하고, 예외 상황 처리 구현

🔍 주요 변경 사항
<!-- 주요 변경 사항과 추가한 기능을 적어주세요. -->

- [x] AuthUserService 작성
- [x] AuthUserRepository find 메소드 작성
- [x] TokenUseCase 작성


✅ 테스트
<!-- 테스트 방법과 시나리오를 간단히 설명해주세요. -->

유닛 테스트: 
토큰 재발급 성공 테스트
+ 주어진 유효한 사용자 ID와 리프레시 토큰을 입력하면 새로운 액세스 및 리프레시 토큰 반환

존재하지 않는 사용자 예외 처리 테스트
+ 존재하지 않는 사용자 ID로 토큰 갱신을 요청하면 UserNotFoundException이 발생
+ 유효하지 않은 리프레시 토큰으로 요청하면 UnAuthorizedException이 발생.


🚧 블로커
<!-- 현재 PR 진행 중 겪고 있는 문제 또는 해결이 필요한 이슈를 적어주세요. -->
없음

⚡ 개선이 필요한 부분
<!-- 코드나 로직의 미흡한 점 또는 개선할 부분이 있다면 적어주세요. -->
개선이 필요한 부분
