### PR TITLE
[ADD] 오픈채팅룸 생성 비즈니스 로직 작성

### DIFF
--- a/src/main/kotlin/com/jongho/hobbytalk/api/common/exception/AlreadyExistsException.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/common/exception/AlreadyExistsException.kt
@@ -1,0 +1,5 @@
+package com.jongho.hobbytalk.api.common.exception
+
+import org.springframework.http.HttpStatus
+
+class AlreadyExistsException(message: String?) : CustomBusinessException(message, HttpStatus.CONFLICT)

--- a/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoom/command/application/repository/OpenChatRoomRepository.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoom/command/application/repository/OpenChatRoomRepository.kt
@@ -1,0 +1,9 @@
+package com.jongho.hobbytalk.api.openChatRoom.command.application.repository
+
+import com.jongho.hobbytalk.api.openChatRoom.command.domain.model.OpenChatRoom
+
+interface OpenChatRoomRepository {
+    fun countByManagerId(managerId: Long): Int
+    fun save(openChatRoom: OpenChatRoom): Long
+    fun findOneByManagerIdAndTitle(managerId: Long, title: String): OpenChatRoom?
+}

--- a/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoom/command/application/service/OpenChatRoomService.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoom/command/application/service/OpenChatRoomService.kt
@@ -1,0 +1,7 @@
+package com.jongho.hobbytalk.api.openChatRoom.command.application.service
+
+import com.jongho.hobbytalk.api.openChatRoom.command.domain.model.OpenChatRoom
+
+interface OpenChatRoomService {
+    fun createOpenChatRoom(openChatRoom: OpenChatRoom): Long
+}

--- a/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoom/command/application/service/OpenChatRoomServiceImpl.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoom/command/application/service/OpenChatRoomServiceImpl.kt
@@ -1,0 +1,24 @@
+package com.jongho.hobbytalk.api.openChatRoom.command.application.service
+
+import com.jongho.hobbytalk.api.common.exception.AlreadyExistsException
+import com.jongho.hobbytalk.api.openChatRoom.command.application.repository.OpenChatRoomRepository
+import com.jongho.hobbytalk.api.openChatRoom.command.common.exception.MaxChatRoomsExceededException
+import com.jongho.hobbytalk.api.openChatRoom.command.domain.model.OpenChatRoom
+
+class OpenChatRoomServiceImpl(private val openChatRoomRepository: OpenChatRoomRepository): OpenChatRoomService {
+    private val MAXIMUM_OPEN_CHAT_ROOM_COUNT = 5
+
+    override fun createOpenChatRoom(openChatRoom: OpenChatRoom): Long {
+        if(openChatRoomRepository.countByManagerId(
+                managerId = openChatRoom.managerId) >= MAXIMUM_OPEN_CHAT_ROOM_COUNT) {
+            throw MaxChatRoomsExceededException("최대 개설 가능한 채팅방 개수를 초과하였습니다.")
+        }
+        if(openChatRoomRepository.findOneByManagerIdAndTitle(
+                managerId = openChatRoom.managerId,
+                title = openChatRoom.title) != null) {
+            throw AlreadyExistsException("이미 존재하는 채팅방입니다.")
+        }
+
+        return openChatRoomRepository.save(openChatRoom)
+    }
+}

--- a/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoom/command/common/exception/MaxChatRoomsExceededException.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoom/command/common/exception/MaxChatRoomsExceededException.kt
@@ -1,0 +1,6 @@
+package com.jongho.hobbytalk.api.openChatRoom.command.common.exception
+
+import com.jongho.hobbytalk.api.common.exception.CustomBusinessException
+import org.springframework.http.HttpStatus
+
+class MaxChatRoomsExceededException(message: String?) : CustomBusinessException(message, HttpStatus.BAD_REQUEST)

--- a/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoom/command/domain/model/OpenChatRoom.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoom/command/domain/model/OpenChatRoom.kt
@@ -1,0 +1,12 @@
+package com.jongho.hobbytalk.api.openChatRoom.command.domain.model
+
+class OpenChatRoom(
+    val id: Long,
+    val title: String,
+    val notice: String,
+    val managerId: Long,
+    val categoryId: Long,
+    val maximumCapacity: Int,
+    val currentAttendance: Int = 0,
+    val password: String?
+)

--- a/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoom/command/domain/model/OpenChatRoom.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoom/command/domain/model/OpenChatRoom.kt
@@ -9,4 +9,26 @@ class OpenChatRoom(
     val maximumCapacity: Int,
     val currentAttendance: Int = 0,
     val password: String?
-)
+) {
+    fun copy(
+        id: Long = this.id,
+        title: String = this.title,
+        notice: String = this.notice,
+        managerId: Long = this.managerId,
+        categoryId: Long = this.categoryId,
+        maximumCapacity: Int = this.maximumCapacity,
+        currentAttendance: Int = this.currentAttendance,
+        password: String? = this.password
+    ): OpenChatRoom {
+        return OpenChatRoom(
+            id,
+            title,
+            notice,
+            managerId,
+            categoryId,
+            maximumCapacity,
+            currentAttendance,
+            password
+        )
+    }
+}

--- a/src/test/kotlin/com/jongho/hobbytalk/api/mock/openChatRoom/OpenChatRoomContainer.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/mock/openChatRoom/OpenChatRoomContainer.kt
@@ -1,0 +1,33 @@
+package com.jongho.hobbytalk.api.mock.openChatRoom
+
+import com.jongho.hobbytalk.api.mock.openChatRoom.repository.FakeOpenChatRoomRepositoryImpl
+import com.jongho.hobbytalk.api.openChatRoom.command.application.service.OpenChatRoomServiceImpl
+
+class OpenChatRoomContainer (){
+    private val map: MutableMap<String, Any> = HashMap()
+
+    init {
+        map[OpenChatRoomBeanKey.OPEN_CHAT_ROOM_REPOSITORY.getValue()] = FakeOpenChatRoomRepositoryImpl()
+        map[OpenChatRoomBeanKey.OPEN_CHAT_ROOM_SERVICE.getValue()] = OpenChatRoomServiceImpl(
+            this.get(key = OpenChatRoomBeanKey.OPEN_CHAT_ROOM_REPOSITORY)
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T> get(key: OpenChatRoomBeanKey): T {
+        return map[key.getValue()] as T
+    }
+}
+
+enum class OpenChatRoomBeanKey(private val value: String) {
+    OPEN_CHAT_ROOM_REPOSITORY("OpenChatRoomRepository"),
+    OPEN_CHAT_ROOM_SERVICE("OpenChatRoomService");
+
+    fun getValue(): String {
+        return value
+    }
+}
+
+fun getOpenChatRoomContainer(): OpenChatRoomContainer {
+    return OpenChatRoomContainer()
+}

--- a/src/test/kotlin/com/jongho/hobbytalk/api/mock/openChatRoom/repository/FakeOpenChatRoomRepositoryImpl.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/mock/openChatRoom/repository/FakeOpenChatRoomRepositoryImpl.kt
@@ -1,0 +1,40 @@
+package com.jongho.hobbytalk.api.mock.openChatRoom.repository
+
+import com.jongho.hobbytalk.api.openChatRoom.command.application.repository.OpenChatRoomRepository
+import com.jongho.hobbytalk.api.openChatRoom.command.domain.model.OpenChatRoom
+import java.util.concurrent.atomic.AtomicLong
+
+class FakeOpenChatRoomRepositoryImpl: OpenChatRoomRepository {
+    private var openChatRoomList: MutableList<OpenChatRoom> = mutableListOf()
+    private var id: AtomicLong = AtomicLong(0)
+
+    override fun countByManagerId(managerId: Long): Int {
+        return openChatRoomList.count { openChatRoom -> openChatRoom.managerId == managerId }
+    }
+
+    override fun findOneByManagerIdAndTitle(managerId: Long, title: String): OpenChatRoom? {
+        return openChatRoomList.firstOrNull{
+            openChatRoom -> (openChatRoom.managerId == managerId && openChatRoom.title == title ) }
+    }
+
+    override fun save(openChatRoom: OpenChatRoom): Long {
+        val openChatRoomId: Long
+        if(openChatRoom.id != 0L) {
+            openChatRoomList[openChatRoomList.indexOfFirst { it -> it.id == openChatRoom.id }] = openChatRoom
+
+            openChatRoomId = openChatRoom.id
+        }
+        else {
+            openChatRoomList.add(openChatRoom.copy(id = id.incrementAndGet()))
+
+            openChatRoomId = id.get()
+        }
+
+        return openChatRoomId
+    }
+
+    fun cleanUp() {
+        openChatRoomList = mutableListOf()
+        id = AtomicLong(0)
+    }
+}

--- a/src/test/kotlin/com/jongho/hobbytalk/api/openChatRoom/application/service/OpenChatRoomServiceImplTest.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/openChatRoom/application/service/OpenChatRoomServiceImplTest.kt
@@ -45,7 +45,7 @@ class OpenChatRoomServiceImplTest {
 
         @Test
         @Description("생성갯수 제한인 5를 초과할 경우 MaxChatRoomsExceededException에 최대 개설 가능한 채팅방 개수를 초과하였습니다. 라는 메세지를 반환한다.")
-        fun 생성갯수_제한인_5를_초과할_경우_MaxChatRoomsExceededException_예외와_최대_개설_가능한_채팅방_개수를_초과하였습니다_라는_메세지를_반환한다(){
+        fun 생성갯수_제한인_5를_초과할_경우_예외와_최대_개설_가능한_채팅방_개수를_초과하였습니다_라는_메세지를_반환한다(){
             //given
             val expectedMessage = "최대 개설 가능한 채팅방 개수를 초과하였습니다."
             for(i in 0..4) {

--- a/src/test/kotlin/com/jongho/hobbytalk/api/openChatRoom/application/service/OpenChatRoomServiceImplTest.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/openChatRoom/application/service/OpenChatRoomServiceImplTest.kt
@@ -1,0 +1,91 @@
+package com.jongho.hobbytalk.api.openChatRoom.application.service
+
+import com.jongho.hobbytalk.api.common.exception.AlreadyExistsException
+import com.jongho.hobbytalk.api.mock.openChatRoom.OpenChatRoomBeanKey
+import com.jongho.hobbytalk.api.mock.openChatRoom.OpenChatRoomContainer
+import com.jongho.hobbytalk.api.mock.openChatRoom.getOpenChatRoomContainer
+import com.jongho.hobbytalk.api.mock.openChatRoom.repository.FakeOpenChatRoomRepositoryImpl
+import com.jongho.hobbytalk.api.openChatRoom.command.application.service.OpenChatRoomServiceImpl
+import com.jongho.hobbytalk.api.openChatRoom.command.common.exception.MaxChatRoomsExceededException
+import com.jongho.hobbytalk.api.openChatRoom.command.domain.model.OpenChatRoom
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.context.annotation.Description
+import kotlin.test.assertEquals
+
+@Description("OpenChatRoomServiceImpl 클래스")
+class OpenChatRoomServiceImplTest {
+    private val openChatRoomServiceImpl: OpenChatRoomServiceImpl
+    private val openChatRoomContainer: OpenChatRoomContainer = getOpenChatRoomContainer()
+
+    init {
+        openChatRoomServiceImpl = openChatRoomContainer.get(OpenChatRoomBeanKey.OPEN_CHAT_ROOM_SERVICE)
+    }
+
+    @Nested
+    @Description("createOpenChatRoom 메소드는")
+    inner class CreateOpenChatRoomMethod{
+        var openChatRoom = OpenChatRoom(
+            id = 0L,
+            title = "title",
+            notice = "notice",
+            managerId = 1L,
+            categoryId = 0L,
+            maximumCapacity = 100,
+            currentAttendance = 0,
+            password = "password"
+        )
+
+        @BeforeEach
+        fun cleanUp() {
+            openChatRoomContainer.get<FakeOpenChatRoomRepositoryImpl>(OpenChatRoomBeanKey.OPEN_CHAT_ROOM_REPOSITORY).cleanUp()
+        }
+
+        @Test
+        @Description("생성갯수 제한인 5를 초과할 경우 MaxChatRoomsExceededException에 최대 개설 가능한 채팅방 개수를 초과하였습니다. 라는 메세지를 반환한다.")
+        fun 생성갯수_제한인_5를_초과할_경우_MaxChatRoomsExceededException_예외와_최대_개설_가능한_채팅방_개수를_초과하였습니다_라는_메세지를_반환한다(){
+            //given
+            val expectedMessage = "최대 개설 가능한 채팅방 개수를 초과하였습니다."
+            for(i in 0..4) {
+                openChatRoomServiceImpl.createOpenChatRoom(
+                    openChatRoom = openChatRoom.copy(title = openChatRoom.title + i))
+            }
+            //when
+            val exception = assertThrows <MaxChatRoomsExceededException> {
+                openChatRoomServiceImpl.createOpenChatRoom(openChatRoom = openChatRoom) }
+
+            //then
+            assertEquals(expectedMessage, exception.message)
+        }
+
+        @Test
+        @Description("중복된 타이틀로 생성을 시도할 경우 AlreadyExistsException에 이미 존재하는 채팅방입니다. 라는 메세지를 반환한다.")
+        fun 중복된_타이틀로_생성을_시도할_경우_AlreadyExistsException에_이미_존재하는_채팅방입니다_라는_메세지를_반환한다(){
+            //given
+            val expectedMessage = "이미 존재하는 채팅방입니다."
+                openChatRoomServiceImpl.createOpenChatRoom(openChatRoom = openChatRoom)
+
+            //when
+            val exception = assertThrows <AlreadyExistsException> {
+                openChatRoomServiceImpl.createOpenChatRoom(openChatRoom = openChatRoom) }
+
+            //then
+            assertEquals(expectedMessage, exception.message)
+        }
+
+        @Test
+        @Description("채팅방 생성에 성공할 경우 저장이 되고 id값을 반환 받는다.")
+        fun 채팅방_생성에_성공할_경우_저장이_되고_id값을_반환_받는다() {
+            //given
+            val expectedId = 1L
+
+            //when
+            val actualId = openChatRoomServiceImpl.createOpenChatRoom(openChatRoom = openChatRoom)
+
+            //then
+            assertEquals(expectedId, actualId)
+        }
+    }
+}


### PR DESCRIPTION
✨ 기능 설명
<!-- 구현한 기능에 대한 간단한 설명을 작성해주세요. -->
오픈채팅방 생성 기능 테스트 및 예외 처리 추가

🔍 주요 변경 사항
<!-- 주요 변경 사항과 추가한 기능을 적어주세요. -->

- [x] OpenChatRoomServiceImpl 클래스에 createOpenChatRoom 메소드 작성
+ 최대 5개의 채팅방만 개설 가능하도록 제한하고, 이를 초과할 경우 MaxChatRoomsExceededException 예외 발생.
+ 동일한 관리자가 동일한 제목의 채팅방을 생성하려고 시도하면 AlreadyExistsException 예외 발생.
+ 유효성을 통과한 채팅방을 저장하고 생성된 ID를 반환.


✅ 테스트
<!-- 테스트 방법과 시나리오를 간단히 설명해주세요. -->

유닛 테스트:
OpenChatRoomServiceImplTest 클래스 작성 및 테스트 케이스 추가
+ 채팅방 생성 제한(5개)을 초과할 경우 적절한 예외와 메시지 검증.
+ 동일한 제목의 채팅방 생성 시 중복 예외 발생 및 메시지 검증.
+ 채팅방 생성 성공 시 반환된 ID 값 검증.


🚧 블로커
<!-- 현재 PR 진행 중 겪고 있는 문제 또는 해결이 필요한 이슈를 적어주세요. -->
없음


⚡ 개선이 필요한 부분
<!-- 코드나 로직의 미흡한 점 또는 개선할 부분이 있다면 적어주세요. -->
