### PR TITLE
Feature/17 open chat room create usecase

### DIFF
--- a/src/main/kotlin/com/jongho/hobbytalk/api/category/command/application/repository/CategoryRepository.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/category/command/application/repository/CategoryRepository.kt
@@ -1,0 +1,7 @@
+package com.jongho.hobbytalk.api.category.command.application.repository
+
+import com.jongho.hobbytalk.api.category.command.domain.model.Category
+
+interface CategoryRepository {
+    fun findOneById(id: Long): Category?
+}

--- a/src/main/kotlin/com/jongho/hobbytalk/api/category/command/application/service/CategoryService.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/category/command/application/service/CategoryService.kt
@@ -1,0 +1,7 @@
+package com.jongho.hobbytalk.api.category.command.application.service
+
+import com.jongho.hobbytalk.api.category.command.domain.model.Category
+
+interface CategoryService {
+    fun findOneById(id: Long): Category?
+}

--- a/src/main/kotlin/com/jongho/hobbytalk/api/category/command/application/service/CategoryServiceImpl.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/category/command/application/service/CategoryServiceImpl.kt
@@ -1,0 +1,10 @@
+package com.jongho.hobbytalk.api.category.command.application.service
+
+import com.jongho.hobbytalk.api.category.command.application.repository.CategoryRepository
+import com.jongho.hobbytalk.api.category.command.domain.model.Category
+
+class CategoryServiceImpl(private val categoryRepository: CategoryRepository): CategoryService {
+    override fun findOneById(id: Long): Category? {
+        return categoryRepository.findOneById(id = id)
+    }
+}

--- a/src/main/kotlin/com/jongho/hobbytalk/api/category/command/domain/model/Category.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/category/command/domain/model/Category.kt
@@ -4,4 +4,16 @@ class Category(
     val id: Long,
     val name: String,
     val parentId: Long
-)
+) {
+    fun copy(
+        id: Long = this.id,
+        name: String = this.name,
+        parentId: Long = this.parentId
+    ): Category {
+        return Category(
+            id = id,
+            name = name,
+            parentId = parentId
+        )
+    }
+}

--- a/src/main/kotlin/com/jongho/hobbytalk/api/category/command/domain/model/Category.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/category/command/domain/model/Category.kt
@@ -1,0 +1,7 @@
+package com.jongho.hobbytalk.api.category.command.domain.model
+
+class Category(
+    val id: Long,
+    val name: String,
+    val parentId: Long
+)

--- a/src/main/kotlin/com/jongho/hobbytalk/api/common/exception/LockAcquisitionException.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/common/exception/LockAcquisitionException.kt
@@ -1,0 +1,5 @@
+package com.jongho.hobbytalk.api.common.exception
+
+import org.springframework.http.HttpStatus
+
+class LockAcquisitionException(message: String) : CustomBusinessException(message, HttpStatus.CONFLICT)

--- a/src/main/kotlin/com/jongho/hobbytalk/api/common/exception/NotFoundException.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/common/exception/NotFoundException.kt
@@ -1,0 +1,5 @@
+package com.jongho.hobbytalk.api.common.exception
+
+import org.springframework.http.HttpStatus
+
+class NotFoundException(message: String) : CustomBusinessException(message, HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/com/jongho/hobbytalk/api/common/lock/repository/LockRepository.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/common/lock/repository/LockRepository.kt
@@ -1,0 +1,6 @@
+package com.jongho.hobbytalk.api.common.lock.repository
+
+interface LockRepository {
+    fun acquireLock(key: String): Boolean
+    fun releaseLock(key: String)
+}

--- a/src/main/kotlin/com/jongho/hobbytalk/api/common/lock/service/LockService.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/common/lock/service/LockService.kt
@@ -1,6 +1,10 @@
 package com.jongho.hobbytalk.api.common.lock.service
 
 interface LockService {
-    fun acquireLock(id: Long): Boolean
-    fun releaseLock(id: Long)
+    fun acquireLock(id: Long, key: LockKey): Boolean
+    fun releaseLock(id: Long, key: LockKey)
+}
+
+interface LockKey {
+    fun getKey(): String
 }

--- a/src/main/kotlin/com/jongho/hobbytalk/api/common/lock/service/LockService.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/common/lock/service/LockService.kt
@@ -1,0 +1,6 @@
+package com.jongho.hobbytalk.api.common.lock.service
+
+interface LockService {
+    fun acquireLock(id: Long): Boolean
+    fun releaseLock(id: Long)
+}

--- a/src/main/kotlin/com/jongho/hobbytalk/api/common/redis/service/RedisLockServiceImpl.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/common/redis/service/RedisLockServiceImpl.kt
@@ -1,25 +1,27 @@
 package com.jongho.hobbytalk.api.common.redis.service
 
 import com.jongho.hobbytalk.api.common.lock.repository.LockRepository
+import com.jongho.hobbytalk.api.common.lock.service.LockKey
+import com.jongho.hobbytalk.api.common.lock.service.LockService
 
-class RedisLockServiceImpl(private val lockRepository: LockRepository) {
-    fun acquireLock(id: Long, key: RedisKey): Boolean {
+class RedisLockServiceImpl(private val lockRepository: LockRepository): LockService {
+    override fun acquireLock(id: Long, key: LockKey): Boolean {
         return lockRepository.acquireLock(genKey(id, key))
     }
 
-    fun releaseLock(id: Long, key: RedisKey) {
+    override fun releaseLock(id: Long, key: LockKey) {
         lockRepository.releaseLock(genKey(id, key))
     }
 
-    private fun genKey(id: Long, key: RedisKey): String {
-        return key.getValue() + id
+    private fun genKey(id: Long, key: LockKey): String {
+        return key.getKey() + id
     }
 }
 
-enum class RedisKey(val value: String) {
+enum class RedisKey(private val key: String): LockKey {
     OPEN_CHAT_ROOM_LIMIT("openChatRoomLimit:userId:");
 
-    fun getValue(): String {
-        return this.value
+    override fun getKey(): String {
+        return this.key
     }
 }

--- a/src/main/kotlin/com/jongho/hobbytalk/api/common/redis/service/RedisLockServiceImpl.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/common/redis/service/RedisLockServiceImpl.kt
@@ -1,0 +1,25 @@
+package com.jongho.hobbytalk.api.common.redis.service
+
+import com.jongho.hobbytalk.api.common.lock.repository.LockRepository
+
+class RedisLockServiceImpl(private val lockRepository: LockRepository) {
+    fun acquireLock(id: Long, key: RedisKey): Boolean {
+        return lockRepository.acquireLock(genKey(id, key))
+    }
+
+    fun releaseLock(id: Long, key: RedisKey) {
+        lockRepository.releaseLock(genKey(id, key))
+    }
+
+    private fun genKey(id: Long, key: RedisKey): String {
+        return key.getValue() + id
+    }
+}
+
+enum class RedisKey(val value: String) {
+    OPEN_CHAT_ROOM_LIMIT("openChatRoomLimit:userId:");
+
+    fun getValue(): String {
+        return this.value
+    }
+}

--- a/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoom/command/application/dto/request/CreateOpenChatRoom.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoom/command/application/dto/request/CreateOpenChatRoom.kt
@@ -1,0 +1,24 @@
+package com.jongho.hobbytalk.api.openChatRoom.command.application.dto.request
+
+import com.jongho.hobbytalk.api.openChatRoom.command.domain.model.OpenChatRoom
+
+data class CreateOpenChatRoom(
+    val title: String,
+    val notice: String,
+    val categoryId: Long,
+    val maximumCapacity: Int,
+    val password: String
+) {
+    fun toModel(managerId: Long): OpenChatRoom {
+        return OpenChatRoom(
+            id = 0L, // ID는 보통 생성 시점에 자동으로 할당
+            title = this.title,
+            notice = this.notice,
+            managerId = managerId,
+            categoryId = this.categoryId,
+            maximumCapacity = this.maximumCapacity,
+            currentAttendance = 1,
+            password = this.password
+        )
+    }
+}

--- a/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoom/command/application/usecase/CreateOpenChatRoomUseCase.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoom/command/application/usecase/CreateOpenChatRoomUseCase.kt
@@ -27,7 +27,7 @@ class CreateOpenChatRoomUseCase(
     }
 
     private fun validateCategory(categoryId: Long) {
-        if (categoryService.findOneById(categoryId) == null) {
+        if (categoryService.findOneById(id = categoryId) == null) {
             throw NotFoundException("존재하지 않는 카테고리입니다.")
         }
     }

--- a/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoom/command/application/usecase/CreateOpenChatRoomUseCase.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoom/command/application/usecase/CreateOpenChatRoomUseCase.kt
@@ -1,0 +1,65 @@
+package com.jongho.hobbytalk.api.openChatRoom.command.application.usecase
+
+import com.jongho.hobbytalk.api.category.command.application.service.CategoryService
+import com.jongho.hobbytalk.api.common.exception.LockAcquisitionException
+import com.jongho.hobbytalk.api.common.exception.NotFoundException
+import com.jongho.hobbytalk.api.common.lock.service.LockService
+import com.jongho.hobbytalk.api.common.redis.service.RedisKey
+import com.jongho.hobbytalk.api.openChatRoom.command.application.dto.request.CreateOpenChatRoom
+import com.jongho.hobbytalk.api.openChatRoom.command.application.service.OpenChatRoomService
+import com.jongho.hobbytalk.api.openChatRoomUser.command.application.service.OpenChatRoomUserService
+import com.jongho.hobbytalk.api.openChatRoomUser.command.domain.model.OpenChatRoomUser
+import org.springframework.transaction.annotation.Transactional
+
+class CreateOpenChatRoomUseCase(
+    private val categoryService: CategoryService,
+    private val lockService: LockService,
+    private val openChatRoomService: OpenChatRoomService,
+    private val openChatRoomUserService: OpenChatRoomUserService
+) {
+    @Transactional
+    fun execute(userId: Long, createOpenChatRoom: CreateOpenChatRoom): Long {
+        validateCategory(createOpenChatRoom.categoryId)
+        val roomId = createRoomWithLock(userId, createOpenChatRoom)
+        saveUserRoomData(userId, roomId)
+
+        return roomId
+    }
+
+    private fun validateCategory(categoryId: Long) {
+        if (categoryService.findOneById(categoryId) == null) {
+            throw NotFoundException("존재하지 않는 카테고리입니다.")
+        }
+    }
+
+    private fun createRoomWithLock(userId: Long, createOpenChatRoom: CreateOpenChatRoom): Long {
+        val maxSpin = 10
+        var spin = 0
+        var roomId = 0L
+
+        while (spin < maxSpin) {
+            if (lockService.acquireLock(userId, RedisKey.OPEN_CHAT_ROOM_LIMIT)) {
+                try {
+                    roomId = openChatRoomService.createOpenChatRoom(createOpenChatRoom.toModel(managerId = userId))
+
+                    return roomId
+                } finally {
+                    lockService.releaseLock(userId, RedisKey.OPEN_CHAT_ROOM_LIMIT)
+                }
+            }
+            spin++
+        }
+
+        throw LockAcquisitionException("락 획득에 실패하였습니다 userId=$userId")
+    }
+
+    private fun saveUserRoomData(userId: Long, roomId: Long) {
+        openChatRoomUserService.save(
+            OpenChatRoomUser(
+                openChatRoomId = roomId,
+                userId = userId,
+                lastExitTime = null,
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoomUser/command/application/repository/OpenChatRoomUserRepository.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoomUser/command/application/repository/OpenChatRoomUserRepository.kt
@@ -1,0 +1,7 @@
+package com.jongho.hobbytalk.api.openChatRoomUser.command.application.repository
+
+import com.jongho.hobbytalk.api.openChatRoomUser.command.domain.model.OpenChatRoomUser
+
+interface OpenChatRoomUserRepository {
+    fun save(openChatRoomUser: OpenChatRoomUser): Long
+}

--- a/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoomUser/command/application/repository/OpenChatRoomUserRepository.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoomUser/command/application/repository/OpenChatRoomUserRepository.kt
@@ -3,5 +3,5 @@ package com.jongho.hobbytalk.api.openChatRoomUser.command.application.repository
 import com.jongho.hobbytalk.api.openChatRoomUser.command.domain.model.OpenChatRoomUser
 
 interface OpenChatRoomUserRepository {
-    fun save(openChatRoomUser: OpenChatRoomUser): Long
+    fun save(openChatRoomUser: OpenChatRoomUser)
 }

--- a/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoomUser/command/application/service/OpenChatRoomUserService.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoomUser/command/application/service/OpenChatRoomUserService.kt
@@ -1,0 +1,7 @@
+package com.jongho.hobbytalk.api.openChatRoomUser.command.application.service
+
+import com.jongho.hobbytalk.api.openChatRoomUser.command.domain.model.OpenChatRoomUser
+
+interface OpenChatRoomUserService {
+    fun save(openChatRoomUser: OpenChatRoomUser): Long
+}

--- a/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoomUser/command/application/service/OpenChatRoomUserService.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoomUser/command/application/service/OpenChatRoomUserService.kt
@@ -3,5 +3,5 @@ package com.jongho.hobbytalk.api.openChatRoomUser.command.application.service
 import com.jongho.hobbytalk.api.openChatRoomUser.command.domain.model.OpenChatRoomUser
 
 interface OpenChatRoomUserService {
-    fun save(openChatRoomUser: OpenChatRoomUser): Long
+    fun save(openChatRoomUser: OpenChatRoomUser)
 }

--- a/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoomUser/command/application/service/OpenChatRoomUserServiceImpl.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoomUser/command/application/service/OpenChatRoomUserServiceImpl.kt
@@ -4,7 +4,7 @@ import com.jongho.hobbytalk.api.openChatRoomUser.command.application.repository.
 import com.jongho.hobbytalk.api.openChatRoomUser.command.domain.model.OpenChatRoomUser
 
 class OpenChatRoomUserServiceImpl(private val openChatRoomUserRepository: OpenChatRoomUserRepository): OpenChatRoomUserService {
-    override fun save(openChatRoomUser: OpenChatRoomUser): Long {
+    override fun save(openChatRoomUser: OpenChatRoomUser){
         return openChatRoomUserRepository.save(openChatRoomUser = openChatRoomUser)
     }
 }

--- a/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoomUser/command/application/service/OpenChatRoomUserServiceImpl.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoomUser/command/application/service/OpenChatRoomUserServiceImpl.kt
@@ -1,0 +1,10 @@
+package com.jongho.hobbytalk.api.openChatRoomUser.command.application.service
+
+import com.jongho.hobbytalk.api.openChatRoomUser.command.application.repository.OpenChatRoomUserRepository
+import com.jongho.hobbytalk.api.openChatRoomUser.command.domain.model.OpenChatRoomUser
+
+class OpenChatRoomUserServiceImpl(private val openChatRoomUserRepository: OpenChatRoomUserRepository): OpenChatRoomUserService {
+    override fun save(openChatRoomUser: OpenChatRoomUser): Long {
+        return openChatRoomUserRepository.save(openChatRoomUser = openChatRoomUser)
+    }
+}

--- a/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoomUser/command/domain/model/OpenChatRoomUser.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoomUser/command/domain/model/OpenChatRoomUser.kt
@@ -5,5 +5,5 @@ import java.time.LocalDateTime
 class OpenChatRoomUser (
     val openChatRoomId: Long,
     val userId: Long,
-    val lastExitTime: LocalDateTime
+    val lastExitTime: LocalDateTime?
 )

--- a/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoomUser/command/domain/model/OpenChatRoomUser.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoomUser/command/domain/model/OpenChatRoomUser.kt
@@ -1,0 +1,9 @@
+package com.jongho.hobbytalk.api.openChatRoomUser.command.domain.model
+
+import java.time.LocalDateTime
+
+class OpenChatRoomUser (
+    val openChatRoomId: Long,
+    val userId: Long,
+    val lastExitTime: LocalDateTime
+)

--- a/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoomUser/command/domain/model/OpenChatRoomUser.kt
+++ b/src/main/kotlin/com/jongho/hobbytalk/api/openChatRoomUser/command/domain/model/OpenChatRoomUser.kt
@@ -6,4 +6,16 @@ class OpenChatRoomUser (
     val openChatRoomId: Long,
     val userId: Long,
     val lastExitTime: LocalDateTime?
-)
+) {
+    fun copy(
+        openChatRoomId: Long = this.openChatRoomId,
+        userId: Long = this.userId,
+        lastExitTime: LocalDateTime? = this.lastExitTime
+    ): OpenChatRoomUser {
+        return OpenChatRoomUser(
+            openChatRoomId = openChatRoomId,
+            userId = userId,
+            lastExitTime = lastExitTime
+        )
+    }
+}

--- a/src/test/kotlin/com/jongho/hobbytalk/api/mock/category/CategoryContainer.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/mock/category/CategoryContainer.kt
@@ -1,0 +1,33 @@
+package com.jongho.hobbytalk.api.mock.category
+
+import com.jongho.hobbytalk.api.category.command.application.service.CategoryServiceImpl
+import com.jongho.hobbytalk.api.mock.category.repository.FakeCategoryRepositoryImpl
+
+object CategoryContainer {
+    private val map: MutableMap<String, Any> = HashMap()
+
+    init {
+        map[CategoryBeanKey.CATEGORY_REPOSITORY.getValue()] = FakeCategoryRepositoryImpl()
+        map[CategoryBeanKey.CATEGORY_SERVICE.getValue()] = CategoryServiceImpl(
+            categoryRepository = this.get(key = CategoryBeanKey.CATEGORY_REPOSITORY)
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T> get(key: CategoryBeanKey): T {
+        return map[key.getValue()] as T
+    }
+}
+
+enum class CategoryBeanKey(private val value: String) {
+    CATEGORY_REPOSITORY("CategoryRepository"),
+    CATEGORY_SERVICE("CategoryService");
+
+    fun getValue(): String {
+        return value
+    }
+}
+
+fun getCategoryContainer(): CategoryContainer {
+    return CategoryContainer
+}

--- a/src/test/kotlin/com/jongho/hobbytalk/api/mock/category/repository/FakeCategoryRepositoryImpl.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/mock/category/repository/FakeCategoryRepositoryImpl.kt
@@ -1,0 +1,32 @@
+package com.jongho.hobbytalk.api.mock.category.repository
+
+import com.jongho.hobbytalk.api.category.command.application.repository.CategoryRepository
+import com.jongho.hobbytalk.api.category.command.domain.model.Category
+import java.util.concurrent.atomic.AtomicLong
+
+class FakeCategoryRepositoryImpl : CategoryRepository {
+    private val categoryList: MutableList<Category> = mutableListOf()
+    private val id = AtomicLong(0)
+
+    override fun findOneById(id: Long): Category? {
+        return categoryList.firstOrNull { it.id == id }
+    }
+
+    fun save(category: Category): Long {
+        val existingIndex = categoryList.indexOfFirst { it.id == category.id }
+
+        if (existingIndex != -1) {
+            categoryList[existingIndex] = category
+        } else {
+            val newCategory = category.copy(id = id.incrementAndGet())
+            categoryList.add(newCategory)
+        }
+
+        return category.id
+    }
+
+    fun cleanUp() {
+        categoryList.clear()
+        id.set(0)
+    }
+}

--- a/src/test/kotlin/com/jongho/hobbytalk/api/mock/common/CommonContainer.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/mock/common/CommonContainer.kt
@@ -1,14 +1,20 @@
 package com.jongho.hobbytalk.api.mock.common
 
+import com.jongho.hobbytalk.api.common.redis.service.RedisLockServiceImpl
+import com.jongho.hobbytalk.api.mock.common.lock.FakeLockRepositoryImpl
 import com.jongho.hobbytalk.api.mock.common.util.FakePasswordHashUtilImpl
 import com.jongho.hobbytalk.api.mock.common.util.FakeTokenUtilImpl
 
-class CommonContainer {
+object CommonContainer {
     private val map: MutableMap<String, Any> = HashMap()
 
     init {
         map[CommonBeanKey.PASSWORD_HASH_UTIL.getValue()] = FakePasswordHashUtilImpl()
         map[CommonBeanKey.TOKEN_UTIL.getValue()] = FakeTokenUtilImpl()
+        map[CommonBeanKey.LOCK_REPOSITORY.getValue()] = FakeLockRepositoryImpl()
+        map[CommonBeanKey.LOCK_SERVICE.getValue()] = RedisLockServiceImpl(
+            lockRepository = this.get(key = CommonBeanKey.LOCK_REPOSITORY)
+        )
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -19,7 +25,9 @@ class CommonContainer {
 
 enum class CommonBeanKey(private val value: String) {
     PASSWORD_HASH_UTIL("PasswordHashUtil"),
-    TOKEN_UTIL("TokenUtil");
+    TOKEN_UTIL("TokenUtil"),
+    LOCK_REPOSITORY("LockRepository"),
+    LOCK_SERVICE("LockService");
 
     fun getValue(): String {
         return value
@@ -27,5 +35,5 @@ enum class CommonBeanKey(private val value: String) {
 }
 
 fun getCommonContainer(): CommonContainer {
-    return CommonContainer()
+    return CommonContainer
 }

--- a/src/test/kotlin/com/jongho/hobbytalk/api/mock/common/lock/FakeLockRepositoryImpl.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/mock/common/lock/FakeLockRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.jongho.hobbytalk.api.mock.common.lock
+
+import com.jongho.hobbytalk.api.common.lock.repository.LockRepository
+
+class FakeLockRepositoryImpl : LockRepository {
+    private val lockSet: MutableSet<String> = mutableSetOf()
+
+    override fun acquireLock(key: String): Boolean {
+        return lockSet.add(key)
+    }
+
+    override fun releaseLock(key: String) {
+        lockSet.remove(key)
+    }
+
+    fun cleanUp() {
+        lockSet.clear()
+    }
+}

--- a/src/test/kotlin/com/jongho/hobbytalk/api/mock/openChatRoom/OpenChatRoomContainer.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/mock/openChatRoom/OpenChatRoomContainer.kt
@@ -1,15 +1,31 @@
 package com.jongho.hobbytalk.api.mock.openChatRoom
 
+import com.jongho.hobbytalk.api.mock.category.CategoryBeanKey
+import com.jongho.hobbytalk.api.mock.category.getCategoryContainer
+import com.jongho.hobbytalk.api.mock.common.CommonBeanKey
+import com.jongho.hobbytalk.api.mock.common.getCommonContainer
 import com.jongho.hobbytalk.api.mock.openChatRoom.repository.FakeOpenChatRoomRepositoryImpl
+import com.jongho.hobbytalk.api.mock.openChatRoomUser.OpenChatRoomUserBeanKey
+import com.jongho.hobbytalk.api.mock.openChatRoomUser.getOpenChatRoomUserContainer
 import com.jongho.hobbytalk.api.openChatRoom.command.application.service.OpenChatRoomServiceImpl
+import com.jongho.hobbytalk.api.openChatRoom.command.application.usecase.CreateOpenChatRoomUseCase
 
-class OpenChatRoomContainer (){
+object OpenChatRoomContainer {
     private val map: MutableMap<String, Any> = HashMap()
+    private val commonContainer = getCommonContainer()
+    private val openChatRoomUserContainer = getOpenChatRoomUserContainer()
+    private val categoryContainer = getCategoryContainer()
 
     init {
         map[OpenChatRoomBeanKey.OPEN_CHAT_ROOM_REPOSITORY.getValue()] = FakeOpenChatRoomRepositoryImpl()
         map[OpenChatRoomBeanKey.OPEN_CHAT_ROOM_SERVICE.getValue()] = OpenChatRoomServiceImpl(
             this.get(key = OpenChatRoomBeanKey.OPEN_CHAT_ROOM_REPOSITORY)
+        )
+        map[OpenChatRoomBeanKey.CREATE_OPEN_CHAT_ROOM_USE_CASE.getValue()] = CreateOpenChatRoomUseCase(
+            categoryService = categoryContainer.get(key = CategoryBeanKey.CATEGORY_SERVICE),
+            lockService = commonContainer.get(key = CommonBeanKey.LOCK_SERVICE),
+            openChatRoomService = this.get(key = OpenChatRoomBeanKey.OPEN_CHAT_ROOM_SERVICE),
+            openChatRoomUserService = openChatRoomUserContainer.get(key = OpenChatRoomUserBeanKey.OPEN_CHAT_ROOM_USER_SERVICE)
         )
     }
 
@@ -21,7 +37,8 @@ class OpenChatRoomContainer (){
 
 enum class OpenChatRoomBeanKey(private val value: String) {
     OPEN_CHAT_ROOM_REPOSITORY("OpenChatRoomRepository"),
-    OPEN_CHAT_ROOM_SERVICE("OpenChatRoomService");
+    OPEN_CHAT_ROOM_SERVICE("OpenChatRoomService"),
+    CREATE_OPEN_CHAT_ROOM_USE_CASE("CreateOpenChatRoomUseCase");
 
     fun getValue(): String {
         return value
@@ -29,5 +46,5 @@ enum class OpenChatRoomBeanKey(private val value: String) {
 }
 
 fun getOpenChatRoomContainer(): OpenChatRoomContainer {
-    return OpenChatRoomContainer()
+    return OpenChatRoomContainer
 }

--- a/src/test/kotlin/com/jongho/hobbytalk/api/mock/openChatRoomUser/OpenChatRoomUserContainer.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/mock/openChatRoomUser/OpenChatRoomUserContainer.kt
@@ -1,0 +1,33 @@
+package com.jongho.hobbytalk.api.mock.openChatRoomUser
+
+import com.jongho.hobbytalk.api.mock.openChatRoomUser.repository.FakeOpenChatRoomUserRepositoryImpl
+import com.jongho.hobbytalk.api.openChatRoomUser.command.application.service.OpenChatRoomUserServiceImpl
+
+object OpenChatRoomUserContainer{
+    private val map: MutableMap<String, Any> = HashMap()
+
+    init {
+        map[OpenChatRoomUserBeanKey.OPEN_CHAT_ROOM_USER_REPOSITORY.getValue()] = FakeOpenChatRoomUserRepositoryImpl()
+        map[OpenChatRoomUserBeanKey.OPEN_CHAT_ROOM_USER_SERVICE.getValue()] = OpenChatRoomUserServiceImpl(
+            openChatRoomUserRepository = this.get(key = OpenChatRoomUserBeanKey.OPEN_CHAT_ROOM_USER_REPOSITORY)
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T> get(key: OpenChatRoomUserBeanKey): T {
+        return map[key.getValue()] as T
+    }
+}
+
+enum class OpenChatRoomUserBeanKey(private val value: String) {
+    OPEN_CHAT_ROOM_USER_REPOSITORY("OpenChatRoomUserRepository"),
+    OPEN_CHAT_ROOM_USER_SERVICE("OpenChatRoomUserService");
+
+    fun getValue(): String {
+        return value
+    }
+}
+
+fun getOpenChatRoomUserContainer(): OpenChatRoomUserContainer {
+    return OpenChatRoomUserContainer
+}

--- a/src/test/kotlin/com/jongho/hobbytalk/api/mock/openChatRoomUser/repository/FakeOpenChatRoomUserRepositoryImpl.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/mock/openChatRoomUser/repository/FakeOpenChatRoomUserRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package com.jongho.hobbytalk.api.mock.openChatRoomUser.repository
+
+import com.jongho.hobbytalk.api.openChatRoomUser.command.application.repository.OpenChatRoomUserRepository
+import com.jongho.hobbytalk.api.openChatRoomUser.command.domain.model.OpenChatRoomUser
+
+class FakeOpenChatRoomUserRepositoryImpl : OpenChatRoomUserRepository {
+    private var roomUserList: MutableList<OpenChatRoomUser> = mutableListOf()
+
+    override fun save(openChatRoomUser: OpenChatRoomUser) {
+        roomUserList.add(openChatRoomUser)
+    }
+
+    fun cleanUp() {
+        roomUserList = mutableListOf()
+    }
+}

--- a/src/test/kotlin/com/jongho/hobbytalk/api/mock/user/UserContainer.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/mock/user/UserContainer.kt
@@ -10,10 +10,8 @@ import com.jongho.hobbytalk.api.user.command.application.service.UserServiceImpl
 import com.jongho.hobbytalk.api.user.command.application.usecase.SignInUseCase
 import com.jongho.hobbytalk.api.user.command.application.usecase.SignUpUseCase
 import com.jongho.hobbytalk.api.user.command.application.usecase.TokenRefreshUseCase
-import com.jongho.hobbytalk.api.user.command.common.util.hash.PasswordHashUtil
-import com.jongho.hobbytalk.api.user.command.common.util.token.TokenUtil
 
-class UserContainer (){
+object UserContainer {
     private val map: MutableMap<String, Any> = HashMap()
     private val commonContainer: CommonContainer = getCommonContainer()
 
@@ -21,19 +19,19 @@ class UserContainer (){
         map[UserBeanKey.USER_REPOSITORY.getValue()] = FakeUserRepositoryImpl()
         map[UserBeanKey.USER_SERVICE.getValue()] = UserServiceImpl(this.get(UserBeanKey.USER_REPOSITORY))
         map[UserBeanKey.SIGN_UP_USE_CASE.getValue()] = SignUpUseCase(
-            passwordHashUtil = commonContainer.get<PasswordHashUtil>(CommonBeanKey.PASSWORD_HASH_UTIL),
+            passwordHashUtil = commonContainer.get(CommonBeanKey.PASSWORD_HASH_UTIL),
             userService = this.get(UserBeanKey.USER_SERVICE)
         )
         map[UserBeanKey.AUTH_USER_REPOSITORY.getValue()] = FakeAuthUserRepositoryImpl()
         map[UserBeanKey.AUTH_USER_SERVICE.getValue()] = AuthUserServiceImpl(this.get(UserBeanKey.AUTH_USER_REPOSITORY))
         map[UserBeanKey.SIGN_IN_USE_CASE.getValue()] = SignInUseCase(
-            tokenUtil = commonContainer.get<TokenUtil>(CommonBeanKey.TOKEN_UTIL),
-            hashUtil = commonContainer.get<PasswordHashUtil>(CommonBeanKey.PASSWORD_HASH_UTIL),
+            tokenUtil = commonContainer.get(CommonBeanKey.TOKEN_UTIL),
+            hashUtil = commonContainer.get(CommonBeanKey.PASSWORD_HASH_UTIL),
             userService = this.get(UserBeanKey.USER_SERVICE),
             authUserRepository = this.get(UserBeanKey.AUTH_USER_REPOSITORY),
         )
         map[UserBeanKey.TOKEN_REFRESH_USE_CASE.getValue()] = TokenRefreshUseCase(
-            tokenUtil = commonContainer.get<TokenUtil>(CommonBeanKey.TOKEN_UTIL),
+            tokenUtil = commonContainer.get(CommonBeanKey.TOKEN_UTIL),
             authUserService = this.get(UserBeanKey.AUTH_USER_SERVICE)
         )
     }
@@ -59,5 +57,5 @@ enum class UserBeanKey(private val value: String) {
 }
 
 fun getUserContainer(): UserContainer {
-    return UserContainer()
+    return UserContainer
 }

--- a/src/test/kotlin/com/jongho/hobbytalk/api/openChatRoom/application/usecase/CreateOpenChatRoomUseCaseTest.kt
+++ b/src/test/kotlin/com/jongho/hobbytalk/api/openChatRoom/application/usecase/CreateOpenChatRoomUseCaseTest.kt
@@ -1,0 +1,129 @@
+package com.jongho.hobbytalk.api.openChatRoom.application.usecase
+
+import com.jongho.hobbytalk.api.category.command.domain.model.Category
+import com.jongho.hobbytalk.api.common.exception.LockAcquisitionException
+import com.jongho.hobbytalk.api.common.exception.NotFoundException
+import com.jongho.hobbytalk.api.mock.category.CategoryBeanKey
+import com.jongho.hobbytalk.api.mock.category.getCategoryContainer
+import com.jongho.hobbytalk.api.mock.category.repository.FakeCategoryRepositoryImpl
+import com.jongho.hobbytalk.api.mock.common.CommonBeanKey
+import com.jongho.hobbytalk.api.mock.common.getCommonContainer
+import com.jongho.hobbytalk.api.mock.common.lock.FakeLockRepositoryImpl
+import com.jongho.hobbytalk.api.mock.openChatRoom.OpenChatRoomBeanKey
+import com.jongho.hobbytalk.api.mock.openChatRoom.getOpenChatRoomContainer
+import com.jongho.hobbytalk.api.mock.openChatRoom.repository.FakeOpenChatRoomRepositoryImpl
+import com.jongho.hobbytalk.api.mock.openChatRoomUser.OpenChatRoomUserBeanKey
+import com.jongho.hobbytalk.api.mock.openChatRoomUser.getOpenChatRoomUserContainer
+import com.jongho.hobbytalk.api.mock.openChatRoomUser.repository.FakeOpenChatRoomUserRepositoryImpl
+import com.jongho.hobbytalk.api.openChatRoom.command.application.dto.request.CreateOpenChatRoom
+import com.jongho.hobbytalk.api.openChatRoom.command.application.usecase.CreateOpenChatRoomUseCase
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.assertThrows
+import org.springframework.context.annotation.Description
+import kotlin.test.Test
+
+@Description("CreateOpenChatRoomUseCase 클래스")
+class CreateOpenChatRoomUseCaseTest {
+    private val createOpenChatRoomUseCase: CreateOpenChatRoomUseCase
+    private val openChatRoomContainer = getOpenChatRoomContainer()
+    private val openChatRoomUserContainer = getOpenChatRoomUserContainer()
+    private val commonContainer = getCommonContainer()
+    private val categoryContainer = getCategoryContainer()
+
+    init {
+        createOpenChatRoomUseCase = openChatRoomContainer.get(OpenChatRoomBeanKey.CREATE_OPEN_CHAT_ROOM_USE_CASE)
+    }
+
+    @Nested
+    @Description("execute 메소드는")
+    inner class ExecuteMethod {
+        private lateinit var createOpenChatRoom: CreateOpenChatRoom
+        private val categoryRepository = categoryContainer.get<FakeCategoryRepositoryImpl>(CategoryBeanKey.CATEGORY_REPOSITORY)
+        private val lockRepository = commonContainer.get<FakeLockRepositoryImpl>(CommonBeanKey.LOCK_REPOSITORY)
+        private val openChatRoomRepository = openChatRoomContainer.get<FakeOpenChatRoomRepositoryImpl>(OpenChatRoomBeanKey.OPEN_CHAT_ROOM_REPOSITORY)
+        private val openChatRoomUserRepository = openChatRoomUserContainer.get<FakeOpenChatRoomUserRepositoryImpl>(
+            OpenChatRoomUserBeanKey.OPEN_CHAT_ROOM_USER_REPOSITORY)
+
+        @BeforeEach
+        fun setUp() {
+            categoryRepository.save(Category(id = 0L, name = "개발", parentId = 0L))
+        }
+
+        @AfterEach
+        fun cleanUp() {
+            categoryRepository.cleanUp()
+            lockRepository.cleanUp()
+            openChatRoomRepository.cleanUp()
+            openChatRoomUserRepository.cleanUp()
+        }
+
+        @Test
+        @Description("카테고리가 유효하고 락을 성공적으로 획득하면 방을 생성하고 방 ID를 반환한다.")
+        fun 카테고리가_유효하고_락을_성공적으로_획득하면_방을_생성하고_방_ID를_반환한다() {
+            // given
+            val expectedId = 1L
+            createOpenChatRoom = CreateOpenChatRoom(
+                title = "타이틀",
+                notice = "공지",
+                categoryId = 1L,
+                maximumCapacity = 10,
+                password = ""
+            )
+
+            // when
+            val roomId = createOpenChatRoomUseCase.execute(userId = 1L, createOpenChatRoom = createOpenChatRoom)
+
+            // then
+            assertEquals(expectedId, roomId)
+        }
+
+        @Test
+        @Description("존재하지 않는 카테고리로 방을 생성하려 하면 NotFoundException을 던진다.")
+        fun 존재하지_않는_카테고리로_방을_생성하려_하면_NotFoundException을_던진다() {
+            // given
+            val expectedMessage = "존재하지 않는 카테고리입니다."
+            createOpenChatRoom = CreateOpenChatRoom(
+                title = "타이틀",
+                notice = "공지",
+                categoryId = 2L,
+                maximumCapacity = 10,
+                password = ""
+            )
+
+            // when
+            val exception = assertThrows<NotFoundException> {
+                createOpenChatRoomUseCase.execute(userId = 1L, createOpenChatRoom = createOpenChatRoom)
+            }
+
+            // then
+            assertEquals(expectedMessage, exception.message)
+        }
+
+        @Test
+        @Description("락 획득에 실패하면 LockAcquisitionException을 던진다.")
+        fun 락_획득에_실패하면_LockAcquisitionException을_던진다() {
+            // given
+            val userId = 1L
+            val expectedMessage = "락 획득에 실패하였습니다 userId=$userId"
+            createOpenChatRoom = CreateOpenChatRoom(
+                title = "타이틀",
+                notice = "공지",
+                categoryId = 1L,
+                maximumCapacity = 10,
+                password = ""
+            )
+            lockRepository.acquireLock(key = "openChatRoomLimit:userId:$userId")
+
+            // when
+            val exception = assertThrows<LockAcquisitionException> {
+                createOpenChatRoomUseCase.execute(userId = userId, createOpenChatRoom = createOpenChatRoom)
+            }
+
+            // then
+            assertEquals(expectedMessage, exception.message)
+        }
+    }
+}


### PR DESCRIPTION
✨ 기능 설명  
<!-- 구현한 기능에 대한 간단한 설명을 작성해주세요. -->  
오픈채팅방 생성 기능 테스트 및 예외 처리 추가  


🔍 주요 변경 사항  
<!-- 주요 변경 사항과 추가한 기능을 적어주세요. -->  

- [x] **CreateOpenChatRoomUseCase 클래스 구현**
  - 카테고리 검증 및 락 획득 처리 로직 추가.
  - 카테고리 유효성 검사 실패 시 `NotFoundException` 발생.
  - 락 획득 실패 시 `LockAcquisitionException` 발생.
  - 방 생성 성공 시 방 ID를 반환.

- [x] **Category 및 관련 로직 추가**
  - `CategoryRepository`, `CategoryService`, `CategoryServiceImpl` 작성.
  - 테스트용 `FakeCategoryRepositoryImpl` 구현.

- [x] **Lock 관리 로직 추가**
  - `LockRepository`, `LockService`, `RedisLockServiceImpl` 작성.
  - 테스트용 `FakeLockRepositoryImpl` 구현.

- [x] **예외 처리 클래스 작성**
  - `LockAcquisitionException` 및 `NotFoundException` 정의.


✅ 테스트  
<!-- 테스트 방법과 시나리오를 간단히 설명해주세요. -->  

**유닛 테스트**  
- `CreateOpenChatRoomUseCaseTest` 작성 및 테스트 케이스 추가:
  - [x] 카테고리 유효성 검증 테스트.
  - [x] 락 획득 성공/실패 시 동작 검증.
  - [x] 방 생성 성공 시 반환 값 검증.


🚧 블로커  
<!-- 현재 PR 진행 중 겪고 있는 문제 또는 해결이 필요한 이슈를 적어주세요. -->  
- 테스트 컨테이너의 참조 문제로 인하여 싱글턴으러 변환 class -> object로 변환하여 해결

⚡ 개선이 필요한 부분  
<!-- 코드나 로직의 미흡한 점 또는 개선할 부분이 있다면 적어주세요. -->  
